### PR TITLE
Tolerate selection of GSControlLayer

### DIFF
--- a/Wordfinder.glyphsPlugin/Contents/Resources/plugin.py
+++ b/Wordfinder.glyphsPlugin/Contents/Resources/plugin.py
@@ -17,7 +17,6 @@ from GlyphsApp import *
 from GlyphsApp.plugins import *
 
 from wordfinder import *
-from texthelper import unichar
 
 class Wordfinder(GeneralPlugin):
     
@@ -44,7 +43,7 @@ class Wordfinder(GeneralPlugin):
 
         for glyph in Glyphs.font.glyphs:
             if glyph.unicode:
-                glyphs.append(unichar(int(glyph.unicode, 16)))
+                glyphs.append(unichr(int(glyph.unicode, 16)))
 
         if not glyphs:
             return
@@ -54,9 +53,10 @@ class Wordfinder(GeneralPlugin):
 
         if font.selectedLayers:
             for layer in font.selectedLayers:
-                glyph = layer.parent
-                if glyph.unicode:
-                    selected.append(unichar(int(glyph.unicode, 16)))
+                if layer.isMemberOfClass_(GSLayer):
+                    glyph = layer.parent
+                    if glyph.unicode:
+                        selected.append(unichr(int(glyph.unicode, 16)))
 
         if not selected:
             return


### PR DESCRIPTION
Prevent this error :
 File "~/Library/Application Support/Glyphs/Plugins/Wordfinder.glyphsPlugin/Contents/Resources/plugin.py", line 57, in findWords
   if glyph.unicode:
AttributeError: 'objc.native_selector' object has no attribute 'unicode'